### PR TITLE
Modify the environment to make time discretization explicit.

### DIFF
--- a/code/environment.py
+++ b/code/environment.py
@@ -2,9 +2,10 @@ import numpy as np
 
 
 class MountainCar(object):
-    def __init__(self, horizon):
-        self.horizon = horizon
-        self.means = np.array([0, 1.0])
+    def __init__(self, horizon_sec=200., dt_sec=1.0):
+        self.horizon_sec = horizon_sec
+        self.dt_sec = dt_sec
+        self.means = np.array([0,1.0])
         self.reset()
 
     def reset(self):
@@ -13,27 +14,26 @@ class MountainCar(object):
         self.pos = -0.5
         self.vel = 0.0
         self.done = False
-        self.h = -1
+        self.h = 0
         return [self.pos, self.vel]
-
+    
     def step(self, action):
-        action = [-1, 0, 1][action]
-        self.h += 1
-        self.vel = max(
-            min(self.vel + 0.001 * action + -0.0025 * np.cos(3 * self.pos), 0.07), -0.07
-        )
-        reward = 0
-
-        if self.pos > 0.6:
+        self.h += self.dt_sec
+        self.vel = max(min(
+            (self.vel + self.dt_sec *(0.001 * action + -0.0025 * np.cos(3 * self.pos))),
+            0.07),-0.07)
+        cost = 0
+        
+        if self.pos >= 0.6:
             # At goal; stay there.
             self.pos = 0.6
             reward = 0.0
         else:
             # Not at goal; move.
-            self.pos = max(self.pos + self.vel, -1.2)
+            self.pos = max(self.pos + self.dt_sec * self.vel, -1.2)
             reward = -1.0
             
-        if self.h == self.horizon-1:
+        if self.h + self.dt_sec > self.horizon_sec:
             self.done = True
             
         return reward, np.array([self.pos, self.vel]), self.h, self.done
@@ -66,7 +66,7 @@ class MountainCar(object):
         pos = np.where(pos <= -1.2, -1.2, pos)
         pos = np.where(pos >= 0.6, 0.6, pos)
         
-        if self.h != self.horizon - 1:
+        if self.h != self.horizon_sec - 1:
             s_ = np.array([pos,vel])
             return cost, s_
         else:
@@ -98,7 +98,7 @@ class MountainCar(object):
         pos = np.where(pos <= -1.2, -1.2, pos)
         pos = np.where(pos >= 0.6, 0.6, pos)
         
-        if self.h != self.horizon - 1:
+        if self.h != self.horizon_sec - 1:
             s_ = np.array([pos,vel])
             return cost, s_
         else:

--- a/code/environment.py
+++ b/code/environment.py
@@ -25,18 +25,19 @@ class MountainCar(object):
         reward = 0
 
         if self.pos > 0.6:
+            # At goal; stay there.
             self.pos = 0.6
+            reward = 0.0
         else:
+            # Not at goal; move.
             self.pos = max(self.pos + self.vel, -1.2)
-
-        if self.h == self.horizon - 1:
+            reward = -1.0
+            
+        if self.h == self.horizon-1:
             self.done = True
-            if self.pos < 0.6:
-                reward = -1.0
-            else:
-                reward = 0.0
-
+            
         return reward, np.array([self.pos, self.vel]), self.h, self.done
+
 
     # Code for broadcasting Mountain Car, might be useful later.
 

--- a/code/tests/test_environment.py
+++ b/code/tests/test_environment.py
@@ -1,25 +1,65 @@
 import unittest
 import logging
 import random
+import numpy as np
 
 from code import environment
 
-# Get logger
-logger = logging.getLogger("__environment__")
-logger.setLevel(logging.INFO)
 
+# Get logger
+logger = logging.getLogger('__test_environment__')
+logger.setLevel(logging.INFO)
+c_handler = logging.StreamHandler()
+logger.addHandler(c_handler)
 
 class Test(unittest.TestCase):
     def test_passing(self):
         self.assertEqual(4, 4)
 
-    def test_create_env(self):
+    def test_run_env(self):
         rng = random.Random(13)
         env = environment.MountainCar(horizon=10)
-        # for s in range(11):
-        #     ret = env.step(rng.choice([-1, 1]))
-        #     logging.info("returned: %r", ret)
-        # reward, state, h, done = env.step(rng.choice([-1, 1]))
-        # logger.info(
-        #     "r: %.1f;  pos: %.2f;  h: %d;  done: %r.",
-        #     reward, state, h, done)
+        rewards = []
+        states = []
+        hs = []
+        dones = []
+        # Collect actual data.
+        logger.info("Running environment.")
+        for s in range(11):
+            ret_vals = env.step(rng.choice([-1, 1]))
+            logger.info("returned values: %r", ret_vals)
+            # logger.info(
+            #     "r: %.1f;  pos: %.2f;  h: %d;  done: %r.",
+            #     reward, state, h, done)
+            reward, state, h, done = ret_vals
+            rewards.append(reward)
+            states.append(state)
+            hs.append(h)
+            dones.append(done)
+
+        # The expected data.
+        expected_rewards = [-1.0] * 11
+        expected_states = np.array([
+            [-0.49917684,  0.00082316],
+            [-0.49753669,  0.00164016],
+            [-0.497091797,  0.000444889747],
+            [-0.4978455, -0.0007537],
+            [-0.49979216, -0.00194666],
+            [-0.50291722, -0.00312506],
+            [-0.50719729, -0.00428007],
+            [-0.51260032, -0.00540303],
+            [-0.51908583, -0.00648551],
+            [-0.52660518, -0.00751935],
+            [-0.53310198, -0.0064968 ],
+        ])
+        expected_hs = list(range(11))
+        expected_dones = [False] * 9 + [True] * 2
+
+        # Check correctness.
+        self.assertEqual(rewards, expected_rewards)
+        self.assertTrue(np.allclose(states, expected_states))
+        self.assertEqual(hs, expected_hs)
+        self.assertEqual(dones, expected_dones)
+        
+
+            


### PR DESCRIPTION
Mountain Car now takes a time discretization argument. The horizon is specified in terms of time as well.

A test is added that ensures that for the same action sequence, the environment at two different time granularities output roughly the same sequence of data.