### PR TITLE
Adaptive Quadrature

### DIFF
--- a/code/adaptive_time/configs/quadrature_mc_tilecoding.json
+++ b/code/adaptive_time/configs/quadrature_mc_tilecoding.json
@@ -1,0 +1,31 @@
+{
+    "env": "mountain_car",
+    "env_kwargs": {
+        "horizon_sec": 200,
+        "dt_sec": 1.0,
+        "es": 200
+    },
+    "seed": 42,
+    "agent_config": {
+        "q_function": "tile_coding",
+        "update_rule": "monte_carlo",
+        "param_init_mean": 10,
+        "param_init_std": 0.0,
+        "iht_size": 4096,
+        "num_tiles": 8,
+        "num_tilings": 8,
+        "learning_rate": 0.0625,
+        "action_space": [-1, 0, 1],
+        "seed": 43
+    },
+    "sampler_config":{
+        "sampler": "adaptive_quadrature",
+        "sampler_kwargs": {
+            "tolerance_init": 0.0005,
+            "integral_rule": "trapezoid"
+        }
+    },
+    "budget": 200000,
+    "num_trajs_per_update": 1,
+    "log_frequency": 1
+}

--- a/code/adaptive_time/main.py
+++ b/code/adaptive_time/main.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from adaptive_time.environment import MountainCar
 from adaptive_time.monte_carlo import mc_policy_iteration
-from adaptive_time.samplers import UniformSampler
+from adaptive_time.samplers import UniformSampler, AdaptiveQuadratureSampler
 from adaptive_time.sarsa import sarsa
 from adaptive_time.q_functions import MountainCarTileCodingQ
 from adaptive_time.utils import parse_dict
@@ -36,6 +36,13 @@ def main(args):
         observation_sampler = UniformSampler(
             env.horizon - 1,
             config.sampler_config.sampler_kwargs.spacing,
+        )
+    elif config.sampler_config.sampler == "adaptive_quadrature":
+        observation_sampler = AdaptiveQuadratureSampler(
+            dt=env.dt_sec,
+            num_steps=env.horizon - 1,
+            tolerance_init=config.sampler_config.sampler_kwargs.tolerance_init,
+            integral_rule=config.sampler_config.sampler_kwargs.integral_rule,
         )
     else:
         raise NotImplementedError

--- a/code/adaptive_time/monte_carlo.py
+++ b/code/adaptive_time/monte_carlo.py
@@ -128,6 +128,7 @@ def mc_policy_iteration(
             max_time=env.horizon,
             dt_sec=env.dt_sec,
         )
+        observation_sampler.adapt(trajs=cont_trajs)
 
         if iter_i % config.log_frequency == 0:
             print(

--- a/code/adaptive_time/q_functions.py
+++ b/code/adaptive_time/q_functions.py
@@ -153,13 +153,13 @@ class MountainCarTileCodingQ(QFunction):
         average_updates = []
         action_frequencies = np.zeros(len(self.action_space))
 
-        for timestep in observe_times[::-1]:
+        for sample_i in range(len(observe_times) - 1, -1, -1):
             # Get action a_t, feature x_t and return G_t
-            curr_acts = disc_trajs["acts"][:, timestep]
+            curr_acts = disc_trajs["acts"][:, sample_i]
             curr_features = np.array(
-                [self.get_feature(obs) for obs in disc_trajs["obss"][:, timestep]]
+                [self.get_feature(obs) for obs in disc_trajs["obss"][:, sample_i]]
             )
-            curr_rets = rets[:, timestep]
+            curr_rets = rets[:, sample_i]
 
             # Compute Q-values
             q_vals = curr_features @ self.parameters
@@ -172,7 +172,7 @@ class MountainCarTileCodingQ(QFunction):
             acts_one_hot = np.eye(len(self.action_space))[curr_acts].reshape(
                 -1, len(self.action_space), 1
             )
-            include_timestep_mask = ep_mask[:, timestep].reshape((-1, 1, 1))
+            include_timestep_mask = ep_mask[:, sample_i].reshape((-1, 1, 1))
 
             per_sample_update = (
                 np.tile(

--- a/code/adaptive_time/samplers.py
+++ b/code/adaptive_time/samplers.py
@@ -60,9 +60,8 @@ class AdaptiveQuadratureSampler(Sampler):
         left_seg = self.integral_rule(rews[t_start:t_mid])
         right_seg = self.integral_rule(rews[t_mid:t_end])
 
-        sample_times = [t_mid]
         if np.abs(curr_seg - left_seg - right_seg) < tolerance:
-            return (sample_times, left_seg + right_seg, 1)
+            return ([], curr_seg, 1)
 
         next_tolerance = 0.5 * tolerance
         left_sample_times, left_seg, left_calls = self._adapt(
@@ -72,6 +71,7 @@ class AdaptiveQuadratureSampler(Sampler):
             rews, t_mid, t_end, right_seg, next_tolerance
         )
 
+        sample_times = [t_mid]
         sample_times.extend(left_sample_times)
         sample_times.extend(right_sample_times)
         sample_times = np.unique(sample_times)
@@ -82,9 +82,9 @@ class AdaptiveQuadratureSampler(Sampler):
         rews = np.mean([traj["rews"] for traj in trajs], axis=0)
         curr_seg = self.integral_rule(rews)
         sample_times, total_seg, num_calls = self._adapt(
-            rews, 0, self.num_steps, curr_seg, self.tolerance_init
+            rews, 0, self.num_steps + 1, curr_seg, self.tolerance_init
         )
-        self._sample_times = np.concatenate(([0], sample_times))
+        self._sample_times = np.concatenate(([0], sample_times)).astype(int)
         return sample_times, total_seg, num_calls
 
     def sample_time(self):

--- a/code/adaptive_time/samplers.py
+++ b/code/adaptive_time/samplers.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractclassmethod
-from typing import Any
+from typing import Any, List
 
 import numpy as np
 
@@ -22,14 +22,57 @@ class UniformSampler(Sampler):
         return np.arange(0, self.num_steps, self.spacing)
 
 
-class QuadratureSampler(Sampler):
-    def __init__(self, num_steps: int, tolerance: float):
+class AdaptiveQuadratureSampler(Sampler):
+    def __init__(
+        self,
+        dt: float,
+        num_steps: int,
+        tolerance_init: float,
+        integral_rule: str = "trapezoid",
+    ):
+        self.dt = dt
         self.num_steps = num_steps
-        self.tolerance = tolerance
-        self._sample_times = [0, 1]
+        self.tolerance_init = tolerance_init
+        self._sample_times = np.arange(num_steps)
 
-    def adapt(self, traj: Any):
-        pass
+        if integral_rule == "trapezoid":
+            self.integral_rule = self._trapezoid_rule
+        else:
+            raise NotImplementedError
+
+    def _trapezoid_rule(self, rews: List[float], t_start: int, t_end: int):
+        return 0.5 * (t_end - t_start) * self.dt * (rews[t_start] + rews[t_end])
+
+    def _adapt(self, rews: List[float], t_start: int, t_end: int, curr_seg: float, tolerance: float):
+        if t_end <= t_start:
+            return ([], 0, 1)
+        
+        t_mid = int(np.floor(0.5 * (t_start + t_end)))
+        left_seg = self.integral_rule(rews, t_start, t_mid)
+        right_seg = self.integral_rule(rews, t_mid, t_end)
+
+        if np.abs(curr_seg - left_seg - right_seg) < 3 * tolerance:
+            sample_times = (t_start, t_end)
+            return (sample_times, left_seg + right_seg, 1)
+        
+        next_tolerance = 0.5 * tolerance
+        left_sample_times, left_seg, left_calls = self._adapt(rews, t_start, t_mid, left_seg, next_tolerance)
+        right_sample_times, right_seg, right_calls = self._adapt(rews, t_mid, t_end, right_seg, next_tolerance)
+
+        sample_times = []
+        sample_times.extend(left_sample_times)
+        sample_times.extend(right_sample_times)
+        sample_times = np.unique(sample_times)
+        
+        return (sample_times, left_seg + right_seg, left_calls + right_calls)
+
+
+    def adapt(self, trajs: Any):
+        rews = np.mean([traj["rews"] for traj in trajs], axis=0)
+        curr_seg = self.integral_rule(rews, 0, self.num_steps)
+        sample_times, total_seg, num_calls = self._adapt(rews, 0, self.num_steps, curr_seg, self.tolerance_init)
+        self._sample_times = sample_times[:-1]
+
 
     def sample_time(self):
         return np.array(self._sample_times)


### PR DESCRIPTION
# Summary
- Add Adaptive Quadrature (AQ)

# Details
Consider timestep $t$ on the most fine-grain trajectory, $r_t$ corresponds to the reward from current state $s_t$ to next state $s_{t + 1}$, so the duration should be based on $[t, t + 1]$.
Consequently, the last reward $r_T$ is dropped because there is no state $s_{T + 1}$.
```
|--s_1--|--s_2--|--s_3--|--s_4--|...|--  s_T  --|
|--a_1--|--a_2--|--a_3--|--a_4--|...|--  a_T  --|
|-------|--r_1--|--r_2--|--r_3--|...|--r_{T-1}--|
```

For computing AQ, however, we also include $r_T$ as we require the right-most boundary of the continuous trajectory.
To that end, although we consider $r_T$, we never include observing $s_T$ and $a_T$ because they have no impact to the return.